### PR TITLE
(chore) cleanup of error messages and fixed treemap helpbox to align …

### DIFF
--- a/shared/components/List/treemap_view.jsx
+++ b/shared/components/List/treemap_view.jsx
@@ -51,16 +51,19 @@ class TreeMap extends Component {
       <div>
       <div className="container">
         <div className="heatMapTitle">
-        <h3>Heat Map of Correlations Between {this.props.keyword.Keyword} and S&P 500 Components</h3>
+        <h3>Heat Map of Correlations Between {this.props.keyword.Keyword} and S&P 500 Components 
+        <OverlayTrigger trigger={["hover","focus","click"]} placement="left" overlay={
+          <Popover id="heatmapInfo" title="Learn More">
+            <strong>Our Process: </strong> The heatmap visualizes the Pearson Correlation Coefficient between the returns of each stock in the S&P 500 (organized by sector), and the historical search volume data of your keyword. 
+              <strong style={{'background-color': 'green', color: 'white'}}>Green</strong> 
+            indicates a positive correlation and 
+              <strong style={{'background-color': 'red', color: 'white'}}>Red</strong> 
+            indicates a negative correlation.  Brightness increases as correlation approaches -1/1. For reference, typically .4-.6 is moderate, .6-.8 is strong, and .8-1.0 is a very strong correlation.  Mouse over a box to see more details, and click to open up a Yahoo Finance window for the stock. Enjoy!
+          </Popover>}>
+              <img src="/img/questionmark.png" width="25" circle/>
+        </OverlayTrigger></h3>
         </div>
       <div className="drop-shadow spacer">
-        <div className="row">
-          <div className="col-md-offset-11">
-            <OverlayTrigger trigger={["hover","focus","click"]} placement="left" overlay={<Popover id="heatmapInfo" title="Learn More"><strong>Our Process: </strong> The heatmap visualizes the Pearson Correlation Coefficient between the returns of each stock in the S&P 500 (organized by sector), and the historical search volume data of your keyword. <strong style={{'background-color': 'green', color: 'white'}}>Green</strong> indicates a positive correlation and <strong style={{'background-color': 'red', color: 'white'}}>Red</strong> indicates a negative correlation.  Brightness increases as correlation approaches -1/1. For reference, typically .4-.6 is moderate, .6-.8 is strong, and .8-1.0 is a very strong correlation.  Mouse over a box to see more details, and click to open up a Yahoo Finance window for the stock. Enjoy!</Popover>}>
-              <img src="/img/questionmark.png" width="25" circle/>
-            </OverlayTrigger>
-          </div>
-        </div>
         <Treemap data={stocks} colors={colorFunction} colorAccessor={colorAccessor} width={1100} height={450} textColor="#484848" fontSize="12px" hoverAnimation={true}/>
       </div>
       </div>

--- a/shared/components/graph.jsx
+++ b/shared/components/graph.jsx
@@ -25,7 +25,7 @@ export class Graph extends Component {
     if (!currentKeyword) {
       return (
         <div>
-          Loading Grapha
+          Loading Graph Data.  Please Note, if excessive wait times occur, this may be due to overuse of GoogleTrends API, which restricts number of queries per day.  We are an academic project for proof of concept only, and we apologize for any inconvienence this may cause.  Please try a different term or wait a few minutes and try again later.
         </div>
       );
     }

--- a/shared/components/news/news_list.jsx
+++ b/shared/components/news/news_list.jsx
@@ -29,10 +29,10 @@ class NewsList extends Component {
   renderArticles() {
     let count = 0;
     return this.props.news.map((article) => {
-      let colorPicker = {'background-color': "white"};
+      let colorPicker = {'backgroundColor': "white"};
       if(this.props.alchemy.url) {
         if (this.props.alchemy.url.indexOf(article.link) >= 0) {
-          colorPicker = {'background-color': "#e6ffe6"};
+          colorPicker = {'backgroundColor': "#e6ffe6"};
         }
       }
       let popOver = (


### PR DESCRIPTION
…with treemap label

1. Cleanup of Loading Messages to tell user that GoogleTrends is rate limited and try again later or a diffferent term.

2. Cleanup of warnings on background-color vs backgroundColor for styling(react uses camelcase apparently).

3. aligned Tooltip in Treemap view with the label so that it doesn't push itself all the way to the right